### PR TITLE
Fix metric-proxy deployment

### DIFF
--- a/config/manifests/500-metric-proxy-deployment.yml
+++ b/config/manifests/500-metric-proxy-deployment.yml
@@ -13,11 +13,11 @@ spec:
     matchLabels:
       app: metric-proxy
   template:
-    annotations:
-      prometheus.io/scrape: true
-      prometheus.io/port: 9090
-      prometheus.io/path: /metrics
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: /metrics
       labels:
         app: metric-proxy
     spec:


### PR DESCRIPTION
Try to deploy cf-for-k8s and we get the following error:
```
error validating data: ValidationError(Deployment.spec.template): unknown field \"annotations\" in io.k8s.api.core.v1.PodTemplateSpec

```