### PR TITLE
Set memory and cpu requests and limit values for all containers

### DIFF
--- a/config/500-metric-proxy-deployment.yml
+++ b/config/500-metric-proxy-deployment.yml
@@ -38,3 +38,10 @@ spec:
           value: cf-workloads
         - name: QUERY_TIMEOUT
           value: "5"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 15m
+            memory: 100Mi


### PR DESCRIPTION
Relint is currently working on a scaling and Quality of Service (QoS) set of stories.

We are targeting 1.0 to be configured out-of-the-box as a "developer" edition aimed at those users who want to kick the tyres.  As part of this, we would like to set limits on mem/cpu.

Since a "developer" edition may not be preferred by everyone, we want each component to be configurable to scale both horizontally (replicas) and vertically (mem/cpu).  This will also allow users to deliver a Guaranteed QoS when required (although we are recommending that all of our pods and containers use the Burstable QoS) As part of this we would like to ask you to do several things:

1. consider which of your pods/containers you would like to expose for scaling properties for.
2. expose said configuration properties.
3. sets mem and cpu values for all containers in order to provide as much meta-data to k8s as possible so that its scheduler can do as good a job as possible. This PR is an initial attempt at setting these values, although we know you are much more likely to have insight into your components mem/cpu requirements than our guess.  

If you have any questions or concerns, please let us know! Thanks! 

[#174462927](https://www.pivotaltracker.com/story/show/174462927)

Co-Authored-By: Carson Long <lcarson@vmware.com>