### PR TITLE
Add CF labels

### DIFF
--- a/ci/validation.yml
+++ b/ci/validation.yml
@@ -259,6 +259,7 @@ jobs:
 
               # write sha to Github release only -- will not exist in repo
               sed -i "s| metric_proxy:.*| metric_proxy: \"oratos/metric-proxy@$new_metric_proxy_image_digest\"|" config/values.yml
+              sed -i "s|version:.*|version: $version|" config/values.yml
             popd
 
             mkdir metric-proxy-release/globs

--- a/config/100-metric-proxy-service-account.yml
+++ b/config/100-metric-proxy-service-account.yml
@@ -4,14 +4,12 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: metric-proxy
-  namespace: #@ data.values.system_namespace
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: metric-proxy
-  namespace: #@ data.values.system_namespace
 rules:
   - apiGroups: ["*"]
     resources: ["pods", "namespaces"]

--- a/config/400-metric-proxy-service.yml
+++ b/config/400-metric-proxy-service.yml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   name: metric-proxy
   namespace: #@ data.values.system_namespace
+  labels: #@ data.values.metadata_labels()
 spec:
   selector:
     app: metric-proxy

--- a/config/400-metric-proxy-service.yml
+++ b/config/400-metric-proxy-service.yml
@@ -1,11 +1,8 @@
-#@ load("@ytt:data", "data")
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: metric-proxy
-  namespace: #@ data.values.system_namespace
-  labels: #@ data.values.metadata_labels()
 spec:
   selector:
     app: metric-proxy

--- a/config/500-metric-proxy-deployment.yml
+++ b/config/500-metric-proxy-deployment.yml
@@ -4,8 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metric-proxy
-  namespace: #@ data.values.system_namespace
-  labels: #@ data.values.metadata_labels()
 spec:
   replicas: 1
   selector:
@@ -17,7 +15,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
-      labels: #@ data.values.metadata_labels()
     spec:
       serviceAccountName: metric-proxy
       containers:

--- a/config/500-metric-proxy-deployment.yml
+++ b/config/500-metric-proxy-deployment.yml
@@ -5,8 +5,7 @@ kind: Deployment
 metadata:
   name: metric-proxy
   namespace: #@ data.values.system_namespace
-  labels:
-    app: metric-proxy
+  labels: #@ data.values.metadata_labels()
 spec:
   replicas: 1
   selector:
@@ -18,8 +17,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
-      labels:
-        app: metric-proxy
+      labels: #@ data.values.metadata_labels()
     spec:
       serviceAccountName: metric-proxy
       containers:

--- a/config/metadata.yml
+++ b/config/metadata.yml
@@ -1,0 +1,28 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ def metadata_labels():
+app: #@ data.values.name
+app.kubernetes.io/name: #@ data.values.name
+app.kubernetes.io/version: #@ data.values.version
+app.kubernetes.io/component: #@ data.values.component
+app.kubernetes.io/part-of: #@ data.values.part_of
+app.kubernetes.io/managed-by: #@ data.values.managed_by
+#@ end
+
+
+#@overlay/match by=overlay.all,expects="1+"
+---
+#@overlay/match-child-defaults missing_ok=True
+metadata:
+  namespace: #@ data.values.system_namespace
+  labels: #@ metadata_labels()
+
+#@overlay/match by=overlay.subset({"kind":"Deployment"}),missing_ok=True
+---
+spec:
+  #@overlay/match-child-defaults missing_ok=True
+  template:
+    metadata:
+      namespace: #@ data.values.system_namespace
+      labels: #@ metadata_labels()

--- a/config/values.yml
+++ b/config/values.yml
@@ -6,16 +6,8 @@ system_namespace: ""
 images:
   metric_proxy: #! This is intentionally blank
 
-#@ def metadata_labels():
-app.kubernetes.io/name: "metric-proxy"
-app.kubernetes.io/version: #! This is intentionally blank
-app.kubernetes.io/component: "container-metrics"
-app.kubernetes.io/part-of: "cloudfoundry"
-app.kubernetes.io/managed-by: "metric-egress"
-#@ end
-
 name: metric-proxy
 component: container-metrics
 part_of: cloudfoundry
 managed_by: metric-egress
-version: dev-test
+version: #! This is intentionally blank

--- a/config/values.yml
+++ b/config/values.yml
@@ -5,3 +5,12 @@ system_namespace: ""
 
 images:
   metric_proxy: #! This is intentionally blank
+
+#@ def metadata_labels():
+app.kubernetes.io/name: "metric-proxy"
+app.kubernetes.io/version: #! This is intentionally blank
+app.kubernetes.io/component: "container-metrics"
+app.kubernetes.io/part-of: "cloudfoundry"
+app.kubernetes.io/managed-by: "metric-egress"
+#@ end
+

--- a/config/values.yml
+++ b/config/values.yml
@@ -14,3 +14,8 @@ app.kubernetes.io/part-of: "cloudfoundry"
 app.kubernetes.io/managed-by: "metric-egress"
 #@ end
 
+name: metric-proxy
+component: container-metrics
+part_of: cloudfoundry
+managed_by: metric-egress
+version: dev-test

--- a/hack/bump-cf-for-k8s.sh
+++ b/hack/bump-cf-for-k8s.sh
@@ -9,8 +9,3 @@ REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && p
 pushd "${CF_FOR_K8s_DIR}"
   vendir sync -d config/metrics/_ytt_lib/metric-proxy="${REPO_DIR}/config"
 popd
-
-# sed -i "s|version:.*|version: dev-test|" $REPO_DIR/config/values.yml
-
-# On Mac
-sed -i .bak "s|version:.*|version: dev-test|" $REPO_DIR/config/values.yml *

--- a/hack/bump-cf-for-k8s.sh
+++ b/hack/bump-cf-for-k8s.sh
@@ -10,3 +10,7 @@ pushd "${CF_FOR_K8s_DIR}"
   vendir sync -d config/metrics/_ytt_lib/metric-proxy="${REPO_DIR}/config"
 popd
 
+# sed -i "s|version:.*|version: dev-test|" $REPO_DIR/config/values.yml
+
+# On Mac
+sed -i .bak "s|version:.*|version: dev-test|" $REPO_DIR/config/values.yml *


### PR DESCRIPTION
[#174735575]

Do these make sense?? This is from the guide here: https://github.com/cloudfoundry-incubator/kubernetes-guidelines

This replaced the `app: metric-proxy` label so we may need to update cf-for-k8s to replace it with the new label. Or for now, I could add it back in?