### PR TITLE
Update limits of metric-proxy. Closes #13

### DIFF
--- a/config/500-metric-proxy-deployment.yml
+++ b/config/500-metric-proxy-deployment.yml
@@ -35,8 +35,8 @@ spec:
           value: "5"
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 30m
+            memory: 25Mi
           requests:
             cpu: 15m
-            memory: 100Mi
+            memory: 10Mi


### PR DESCRIPTION
Did some testing with siege and didn't see cpu or memory spiking. These lower values still fit our needs and are more efficient.