### PR TITLE
[PoC] Add disk usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:1.13 as builder
 
-COPY / /metric-proxy/
+RUN mkdir /metric-proxy
+WORKDIR /metric-proxy
 
-RUN cd /metric-proxy && make
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+RUN make
 
 FROM ubuntu:bionic
 

--- a/config/100-metric-proxy-service-account.yml
+++ b/config/100-metric-proxy-service-account.yml
@@ -12,7 +12,7 @@ metadata:
   name: metric-proxy
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "namespaces"]
+    resources: ["pods", "namespaces", "nodes/proxy"]
     verbs: ["get", "watch", "list"]
 
 ---

--- a/hack/build-dev-image.sh
+++ b/hack/build-dev-image.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euo pipefail
+
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 
 pushd $REPO_DIR

--- a/pkg/metrics/proxy_test.go
+++ b/pkg/metrics/proxy_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -376,7 +377,13 @@ func TestMetricsProxyRead(t *testing.T) {
 }
 
 func startGRPCServer(f Fetcher, addEnvelopes bool) (stop func(), err error) {
-	c := &Proxy{f, addEnvelopes}
+	c := &Proxy{
+		GetMetrics: f,
+		GetDiskUsage: func(string) (PodDiskUsage, error) {
+			return PodDiskUsage{}, errors.New("foo")
+		},
+		AddEmptyDiskEnvelope: addEnvelopes,
+	}
 
 	s := grpc.NewServer()
 	logcache_v1.RegisterEgressServer(s, c)


### PR DESCRIPTION
In Eirini team we are maintaining [a component for metrics](https://github.com/cloudfoundry-incubator/eirini/tree/master/cmd/metrics-collector) which isn't used in cf-for-k8s. We would like to deprecate that component but the [one used in cf-for-k8s](https://github.com/cloudfoundry/metric-proxy) doesn't support disk usage yet.

This PR is a PoC that makes disk usage metrics work in metric-proxy.

TODOs:
- Fix tests
- Add tests for new functionality
- Possibly add caching for the fetched metrics since they contain information for more than the requested pod and thus could be reused.

More to consider:

The current implementation doesn't add the image size in the calculated total. That means that an application like [dora](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop/assets/dora) when first pushed it appears as if it consumes just 12K of disk, although there is a number of gems obviously pulled in (but are part of the docker image).

The image sizes are available under the "/api/v1/nodes" endpoint.

You can check with:

```
$ # Start a proxy to the kubernetes api
$ kubectl proxy --api-prefix=/
$ curl localhost:8001/api/v1/nodes | jq '.items[0].status.images' --color-output | less -R
```

https://www.pivotaltracker.com/story/show/175935123