### PR TITLE
Allow caching of go modules during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM golang:1.13 as builder
 
-COPY / /metric-proxy/
+RUN mkdir /metric-proxy
+WORKDIR /metric-proxy
 
-RUN cd /metric-proxy && make
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+RUN make
 
 FROM ubuntu:bionic
 


### PR DESCRIPTION
Just a little improvement of the dockerfile structure.

By moving the dependency fetching to above the source code copying, the dependences can be cached by docker, saving them being retrieved on each build.