### PR TITLE
Make build-dev-image script fail when something fails

### DIFF
--- a/hack/build-dev-image.sh
+++ b/hack/build-dev-image.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euo pipefail
+
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 
 pushd $REPO_DIR


### PR DESCRIPTION
A one-liner so that a failing `make test` stops the script.